### PR TITLE
default the defaults to 'default'

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ rather they use entities already existing in your Cloud Foundry:
 
 ```
 params:
-  shield_network:   shield
-  shield_disk_pool: shield # should be at least 1GB
-  shield_vm_type:   small # VMs should have at least 1 CPU, and 1GB of memory
+  shield_network:   default
+  shield_disk_pool: default # should be at least 1GB
+  shield_vm_type:   default # VMs should have at least 1 CPU, and 1GB of memory
 ```
 
 [1]: https://github.com/starkandwayne/shield

--- a/base/params.yml
+++ b/base/params.yml
@@ -1,9 +1,9 @@
 ---
 params:
   installation:     S.H.I.E.L.D. Alpha
-  shield_disk_pool: shield
-  shield_vm_type:   small
-  shield_network:   shield
+  shield_disk_pool: default
+  shield_vm_type:   default
+  shield_network:   default
 
   availability_zones:
   - z1


### PR DESCRIPTION
In bosh-deployment cloud-config.yml there are defaults of 'default'
for vm_types, disk_types, and networks.

e.g. https://github.com/cloudfoundry/bosh-deployment/blob/master/aws/cloud-config.yml