### PR TITLE
Upgrade to SHIELD release v7.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,12 @@ Params
 
 #### Base Params
 
-There are no required params for SHIELD, when deployed with no subkits enabled.
-However, the following params can be overridden to customize your installation
+There is one required params for SHIELD when deployed with no subkits enabled.
+
+- **parms.shield_static_ip** - Choose a static IP from the network in your Cloud Config.
+  External SHIELD agents will call home to this IP.
+
+Additionally, the following params can be overridden to customize your installation
 if needed:
 
 - **params.installation** - controls the name of the SHIELD installation, as reported

--- a/README.md
+++ b/README.md
@@ -43,14 +43,6 @@ how users authenticate to SHIELD. One of these three must be specified
 - **http-auth** - Sets up HTTP Basic Authentication and a single user/password
   to be used by SHIELD for authenticating.
 
-#### Azure
-
-When deploying SHIELD on azure, you may want to consider the `azure` subkit for
-reconfiguring the availability zones in play. Since Azure uses availability sets,
-rather than zones, there is typically only one zone in play for networks/VMs,
-and the availability set would be defined by the Azure CPI automatically, or via
-`cloud_properties` in your Cloud Config.
-
 Params
 ------
 

--- a/base/params.yml
+++ b/base/params.yml
@@ -5,7 +5,4 @@ params:
   shield_vm_type:   small
   shield_network:   shield
 
-  availability_zones:
-  - z1
-  - z2
-  - z3
+  availability_zones: [z1]

--- a/base/params.yml
+++ b/base/params.yml
@@ -5,4 +5,4 @@ params:
   shield_vm_type:   small
   shield_network:   shield
 
-  availability_zones: [z1]
+  availability_zone: z1

--- a/base/properties.yml
+++ b/base/properties.yml
@@ -2,13 +2,6 @@
 meta:
   vault: (( concat "secret/" params.vault ))
 
-update:
-  serial: false
-  canaries: 1
-  canary_watch_time: 30000-120000
-  max_in_flight: 1
-  update_watch_time: 30000-120000
-
 instance_groups:
   - name: shield
     instances: 1
@@ -18,56 +11,56 @@ instance_groups:
     stemcell: ubuntu
     networks:
       - name: (( grab params.shield_network ))
-        static_ips: (( static_ips 0 ))
+        static_ips: (( grab params.shield_static_ip ))
     jobs:
-      - { release: shield, name: postgres      }
-      - { release: shield, name: shield-daemon }
-      - { release: shield, name: shield-agent  }
-      - { release: shield, name: agent-pgtools }
-      - { release: shield, name: nginx         }
-
-    properties:
-      databases:
-        db_scheme: postgres
-        address:   127.0.0.1
-        port:      5524
-        databases:
-          - name: shield
-        roles:
-          - name: shield
+      - name: postgres
+        release: shield
+        properties:
+          databases:
+          - {name: shield,   tag: shield,   citext: true}
+          roles:
+          - name: shieldadmin
             password: (( vault meta.vault "/database/shield:password" ))
-
-      shield:
-        provisioning_key: (( vault meta.vault "/provisioning:key" ))
-        agent:
-          autoprovision: (( concat "https://" instance_groups.shield.properties.shield.daemon.domain ))
-        daemon:
+            tag: admin
+      - name: shield-daemon
+        release: shield
+        provides:
+          shield-daemon: {shared: true, as: shield-daemon}
+        properties:
           name:   (( grab params.installation ))
-          domain: (( grab instance_groups.shield.networks[0].static_ips[0] ))
-
+          domain: (( grab params.shield_static_ip ))
           ssh_private_key: (( vault meta.vault "/agent:private" ))
-
           auth:
-            basic_user:      shield
-            basic_password:  (( vault meta.vault "/webui:password" ))
+            username: shield
+            password:  (( vault meta.vault "/webui:password" ))
             api_keys:
               autoprovision: (( vault meta.vault "/provisioning:key" ))
+          ssl:
+            crt: (( vault meta.vault "/shield/certs/server:certificate" ))
+            key: (( vault meta.vault "/shield/certs/server:key" ))
+      - name: shield-agent
+        release: shield
+        consumes:
+          shield-daemon: {from: shield-daemon}
+        properties:
+          autoprovision: true
+          schedules: {default: daily 3am}
+          retention-policies: {default: 30}
 
-          database:
-            type:     postgres
-            db:       shield
-            host:     (( grab instance_groups.shield.properties.databases.address ))
-            port:     (( grab instance_groups.shield.properties.databases.port ))
-            username: (( grab instance_groups.shield.properties.databases.roles.0.name ))
-            password: (( grab instance_groups.shield.properties.databases.roles.0.password ))
+update:
+  canaries: 0
+  max_in_flight: 1
+  serial: true
+  canary_watch_time: 1000-120000
+  update_watch_time: 1000-120000
+
+stemcells:
+- alias: ubuntu
+  os: ubuntu-trusty
+  version: latest
 
 releases:
 - name: shield
-  version: 6.8.0
-  sha1: 1b9795956439132d510547a96d817602d21eb8c4
-  url: https://bosh.io/d/github.com/starkandwayne/shield-boshrelease?v=6.8.0
-
-stemcells:
-- os: ubuntu-trusty
-  version: latest
-  alias: ubuntu
+  version: 7.0.1
+  url: https://github.com/starkandwayne/shield-boshrelease/releases/download/v7.0.1/shield-7.0.1.tgz
+  sha1: 59523e113c2276a54eca308aa1ca944fd6e3a99c

--- a/base/properties.yml
+++ b/base/properties.yml
@@ -5,7 +5,7 @@ meta:
 instance_groups:
   - name: shield
     instances: 1
-    azs: (( grab params.availability_zones ))
+    azs: [(( grab params.availability_zone ))]
     persistent_disk_pool: (( grab params.shield_disk_pool ))
     vm_type:              (( grab params.shield_vm_type   ))
     stemcell: ubuntu

--- a/kit.yml
+++ b/kit.yml
@@ -26,12 +26,20 @@ params:
         External SHIELD agents will call home to this IP.
       param: shield_static_ip
       validate: /((^|\.)([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])){4}/
+    - description: The name of the BOSH network to deploy the server
+      param: shield_network
+    - description: The name of the BOSH disk type to give server
+      param: shield_disk_pool
+    - description: The name of the BOSH VM type for the server
+      param: shield_vm_type
+
   github-oauth:
     - ask: What is your GitHub OAuth Client ID?
       description: |
         The GitHub OAuth Client Key is used to authenticate SHIELD to GitHub,
         so that SHIELD can then authorize users after they log into GitHub. GitHub refers
         to this as the `client_id`. See https://developer.github.com/v3/oauth/ for more info.
+
       vault: oauth:provider_key
     - ask: What is your GitHub OAuth Client Secret?
       description: |

--- a/kit.yml
+++ b/kit.yml
@@ -23,12 +23,15 @@ params:
         External SHIELD agents will call home to this IP.
       param: shield_static_ip
       validate: /((^|\.)([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])){4}/
+
     - description: The name of the BOSH network to deploy the server
       param: shield_network
     - description: The name of the BOSH disk type to give server
       param: shield_disk_pool
     - description: The name of the BOSH VM type for the server
       param: shield_vm_type
+    - description: Availability Zone for the server
+      param: availability_zone
 
   github-oauth:
     - ask: What is your GitHub OAuth Client ID?

--- a/kit.yml
+++ b/kit.yml
@@ -19,6 +19,13 @@ subkits:
   subkit: azure
 
 params:
+  base:
+    - ask: Choose a static IP for the daemon API?
+      description: |
+        Choose a static IP from the network in your Cloud Config.
+        External SHIELD agents will call home to this IP.
+      param: shield_static_ip
+      validate: /((^|\.)([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])){4}/
   github-oauth:
     - ask: What is your GitHub OAuth Client ID?
       description: |
@@ -56,7 +63,16 @@ params:
       param: authz_allowed_groups
 
 
-certificates: {}
+certificates:
+  base:
+    shield/certs:
+      ca: { valid_for: 1y }
+      server:
+        valid_for: 1y
+        names:
+        - "127.0.0.1"
+        # - "*.shield.${params.shield_network}.shield.bosh"
+        - "${params.shield_static_ip}"
 
 credentials:
   base:

--- a/kit.yml
+++ b/kit.yml
@@ -24,6 +24,8 @@ params:
       param: shield_static_ip
       validate: /((^|\.)([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])){4}/
 
+    - description: Title of SHIELD installation
+      param: installation
     - description: The name of the BOSH network to deploy the server
       param: shield_network
     - description: The name of the BOSH disk type to give server

--- a/kit.yml
+++ b/kit.yml
@@ -15,9 +15,6 @@ subkits:
     - subkit: ~
       label: HTTP Basic Auth
 
-- prompt: Are you deploying SHIELD on Azure?
-  subkit: azure
-
 params:
   base:
     - ask: Choose a static IP for the daemon API?

--- a/subkits/azure/params.yml
+++ b/subkits/azure/params.yml
@@ -1,5 +1,0 @@
----
-params:
-  availability_zones:
-  - (( replace ))
-  - z1


### PR DESCRIPTION
Major changes to manifest to support links + cloud-config; but same
version of SHIELD itself as v6.9.0

Static IP is now an "ask", and it is included in the generated SSL certs.

Removed Azure prompt. Always use single 'z1' az by default.

Server vm_type, disk_type, network are included in env.yml file
for easy overriding.

**Subkits to update/test:**

* [ ] cf-oauth - configure additional sessions db
* [ ] github-oauth - configure additional sessions db