### PR TITLE
Use Xenial by default, upgrade to v8.0.16

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -43,7 +43,7 @@ infrastructure and application data.
   `shield`.
 
 - `stemcell_os` - The operating system you want to deploy SHIELD
-  on.  This defaults to `ubuntu-trusty`.
+  on.  This defaults to `ubuntu-xenial`.
 
 - `stemcell_version` - The version of the stemcell to deploy.
   Defaults to `latest`, which is usually what you want.

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,11 @@
+# Improvements
+
+- Updated to use Xenial stemcells by default
+- Updated SHIELD to v8.0.16
+
+
+# Software Components	
+ | Name | Version | Release Notes |	
+| --- | --- | --- |	
+| SHIELD | 8.0.16 | [Release Notes][v8.0.16] |
+ [v8.0.16]: https://github.com/starkandwayne/shield/releases/tag/v8.0.16

--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -2,7 +2,7 @@
 meta:
   kit:     shield
   release: S.H.I.E.L.D. Genesis Kit
-  target:  pipes-genesis
+  target:  buf
   url:     https://10.200.131.2.netip.cc
 
   initial_version: 0.3.0

--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -2,7 +2,7 @@
 meta:
   kit:     shield
   release: S.H.I.E.L.D. Genesis Kit
-  target:  buf
+  target:  pipes-genesis
   url:     https://10.200.131.2.netip.cc
 
   initial_version: 0.3.0

--- a/manifests/releases.yml
+++ b/manifests/releases.yml
@@ -1,5 +1,5 @@
 releases:
 - name:    shield
-  version: 8.0.15
-  url:     https://github.com/starkandwayne/shield-boshrelease/releases/download/v8.0.15/shield-8.0.15.tgz
-  sha1:    7792821099e12709a1ec633efa9b3c7d963e3361
+  version: 8.0.16
+  url:     https://github.com/starkandwayne/shield-boshrelease/releases/download/v8.0.16/shield-8.0.16.tgz
+  sha1:    8a0ececa11e995834824bb3c8cba1c5301b09a03

--- a/manifests/shield.yml
+++ b/manifests/shield.yml
@@ -10,7 +10,7 @@ instance_groups:
     azs: [(( grab params.availability_zone || "z1" ))]
     persistent_disk_pool: (( grab params.shield_disk_pool || "shield" ))
     vm_type:              (( grab params.shield_vm_type   || "small"  ))
-    stemcell: default
+    stemcell: xenial
     networks:
       - name: (( grab params.shield_network || "shield" ))
         static_ips:
@@ -57,6 +57,6 @@ update:
   update_watch_time: 1000-120000
 
 stemcells:
-- alias:   default
-  os:      (( grab params.stemcell_os      || "ubuntu-trusty" ))
+- alias:   xenial
+  os:      (( grab params.stemcell_os      || "ubuntu-xenial" ))
   version: (( grab params.stemcell_version || "latest" ))


### PR DESCRIPTION
This PR changes the kit to use Xenial stemcells by default, and updates the BOSH release to v8.0.16, which itself doesn't bring any changes notable to Kit configuration.