### PR TITLE
genesis new fails exits abruptly when $external_domain is not provided

### DIFF
--- a/hooks/new
+++ b/hooks/new
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -eux
 
 ip= # assigned below with prompt_for
 prompt_for ip line \
@@ -30,5 +30,8 @@ genesis_config_block
 
 echo "params:"
 echo "  shield_static_ip: $ip"
-[[ -n "$external_domain" ]] && echo "  external_domain: $external_domain"
+#[[ -n "$external_domain" ]] && echo "  external_domain: $external_domain"
+if [[ -n "$external_domain" ]] ; then
+  echo "  external_domain: $external_domain"
+fi
 ) > "$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml"

--- a/hooks/new
+++ b/hooks/new
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux
+set -eu
 
 ip= # assigned below with prompt_for
 prompt_for ip line \
@@ -30,7 +30,6 @@ genesis_config_block
 
 echo "params:"
 echo "  shield_static_ip: $ip"
-#[[ -n "$external_domain" ]] && echo "  external_domain: $external_domain"
 if [[ -n "$external_domain" ]] ; then
   echo "  external_domain: $external_domain"
 fi


### PR DESCRIPTION
As per the title, it replaces offending oneliner and adds an if statement which addresses the following error:

```
➜  shield git:(master) genesis new snw-itsouvalas-lab --kit shield/1.11.0

Setting up new environment snw-itsouvalas-lab based on kit shield/1.11.0 ...

Verifying availability of vault 'lab' (https://vault.lab.starkandwayne.com)...ok


What IP address would you like to deploy SHIELD on?
> 10.128.184.12

What domain name would you like to use? (leave blank to just use IP)
> 

Would you like to authenticate against an OAuth2 endpoint (Github / UAA)?
[y|n] > y
[ERROR] Could not create new env snw-itsouvalas-lab (in ~/sw/deployments/shield): 'new' hook exited 1
```