### PR TITLE
Add 'secure' feature

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -66,6 +66,12 @@ infrastructure and application data.
   Github or UAA.  See the _Examples_ section for more details on
   properly configuring Github and UAA providers.
 
+- `secure` - Configure the admin user account.  By default, the admin user
+  account credentials are static.  Use this feature to have a password
+  generated automatically and optionally specify an alternative username with
+  by setting `params.admin_username` in the environment file.  The password
+  can then be rotated as needed by your company's security policy.
+
 # Cloud Configuration
 
 By default, SHIELD uses the following VM types/networks/disk pools from your

--- a/ci/envs/ci.yml
+++ b/ci/envs/ci.yml
@@ -2,4 +2,8 @@
 kit:
   name: dev
   version: latest
-  features: []
+  features:
+  - secure
+
+params:
+  admin_username: shield_admin

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -4,12 +4,13 @@ set -eu
 declare -a merge
 
 validate_features oauth oauth-provider \
-                  proxy postgres-addon
+                  proxy postgres-addon secure
 
 merge=( manifests/shield.yml manifests/releases/shield.yml )
 
 want_feature oauth && merge+=( manifests/oauth.yml )
 want_feature postgres-addon && merge+=( manifests/addons/postgres.yml manifests/releases/shield-addon-postgres.yml )
+want_feature secure && merge+=( manifests/addons/secure.yml )
 
 if want_feature oauth-provider; then
   echo >&2 "The oauth-provider feature flag is now just called 'oauth'."

--- a/hooks/new
+++ b/hooks/new
@@ -11,17 +11,28 @@ prompt_for external_domain line \
   --default ''
 
 isoauth= # assigned below with prompt_for
-prompt_for isoauth boolean \
-	'Would you like to authenticate against an OAuth2 endpoint (Github / UAA)?'
+prompt_for isoauth boolean -i --default 'false' \
+	'Would you like to authenticate against an OAuth2 endpoint (Github / UAA)? [y|N]'
+
+secure=
+prompt_for secure boolean -i  --default  'true' \
+  'Would you like to secure the admin user with a generated password and optional username? [Y|n]'
+
+username='admin'
+if $secure ; then
+  prompt_for username line -i --default $username \
+    'Admin username:'
+fi
 
 (
 echo "---"
 echo "kit:"
 echo "  name:    $GENESIS_KIT_NAME"
 echo "  version: $GENESIS_KIT_VERSION"
-if [[ $isoauth == 'true' ]]; then
+if $isoauth || $secure; then
 	echo "  features:"
-	echo "    - oauth"
+  $isoauth && echo "    - oauth"
+  $secure && echo "    - secure"
 else
 	echo "  features: []"
 fi
@@ -32,5 +43,8 @@ echo "params:"
 echo "  shield_static_ip: $ip"
 if [[ -n "$external_domain" ]] ; then
   echo "  external_domain: $external_domain"
+fi
+if [[ "$username" != "admin" ]] ; then
+  echo "  admin_username: $username"
 fi
 ) > "$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml"

--- a/kit.yml
+++ b/kit.yml
@@ -29,3 +29,7 @@ certificates:
 credentials:
   base:
     agent: ssh 2048 fixed
+
+  secure:
+    failsafe:
+      admin_password: random 24

--- a/manifests/addons/secure.yml
+++ b/manifests/addons/secure.yml
@@ -1,0 +1,13 @@
+---
+exodus:
+  admin_username: (( grab params.admin_username || "admin" ))
+  admin_password: (( vault meta.vault "/failsafe:admin_password" ))
+
+instance_groups:
+- name: shield
+  jobs:
+  - name: core
+    properties:
+      failsafe:
+        username: (( grab params.admin_username || "admin" ))
+        password: (( vault meta.vault "/failsafe:admin_password" ))

--- a/manifests/shield.yml
+++ b/manifests/shield.yml
@@ -6,8 +6,8 @@ exodus:
   url:     (( concat "https://" params.external_domain ))
   ca_cert: (( vault meta.vault "/certs/ca:certificate" ))
   pubkey:  (( vault meta.vault "/agent:public" ))
-  admin_username: (( grab instance_groups.shield.jobs.core.properties.failsafe.username || "admin" ))
-  admin_password: (( grab instance_groups.shield.jobs.core.properties.failsafe.password || "shield" ))
+  admin_username: "admin"
+  admin_password: "shield"
 
 instance_groups:
   - name: shield

--- a/spec/deployments/secure.yml
+++ b/spec/deployments/secure.yml
@@ -1,0 +1,12 @@
+---
+kit:
+  features:
+  - secure
+
+genesis:
+  env:   secure
+
+params:
+  shield_static_ip: 10.99.0.16
+  installation:     S.H.I.E.L.D. CI/CD
+  admin_username:   superuser

--- a/spec/results/base.yml
+++ b/spec/results/base.yml
@@ -1,9 +1,12 @@
 exodus:
   admin_password: shield
   admin_username: admin
+  bosh: base
   ca_cert: <!{meta.vault}/certs/ca:certificate!>
+  is_director: false
   pubkey: <!{meta.vault}/agent:public!>
   url: https://10.99.0.16
+  use_create_env: false
 instance_groups:
 - azs:
   - z1

--- a/spec/results/oauth.yml
+++ b/spec/results/oauth.yml
@@ -1,9 +1,12 @@
 exodus:
   admin_password: shield
   admin_username: admin
+  bosh: oauth
   ca_cert: <!{meta.vault}/certs/ca:certificate!>
+  is_director: false
   pubkey: <!{meta.vault}/agent:public!>
   url: https://10.99.0.16
+  use_create_env: false
 instance_groups:
 - azs:
   - z1

--- a/spec/results/secure.yml
+++ b/spec/results/secure.yml
@@ -1,7 +1,7 @@
 exodus:
-  admin_password: shield
-  admin_username: admin
-  bosh: postgres
+  admin_password: <!{meta.vault}/failsafe:admin_password!>
+  admin_username: superuser
+  bosh: secure
   ca_cert: <!{meta.vault}/certs/ca:certificate!>
   is_director: false
   pubkey: <!{meta.vault}/agent:public!>
@@ -31,6 +31,9 @@ instance_groups:
       core:
         env: S.H.I.E.L.D. CI/CD
       domain: 10.99.0.16
+      failsafe:
+        password: <!{meta.vault}/failsafe:admin_password!>
+        username: superuser
       require-shield-core: true
       tls:
         certificate: <!{meta.vault}/certs/server:certificate!>
@@ -45,8 +48,6 @@ instance_groups:
         as: shield
         shared: true
     release: shield
-  - name: shield-addon-postgres-11
-    release: shield-addon-postgres
   name: shield
   networks:
   - name: shield
@@ -55,16 +56,12 @@ instance_groups:
   persistent_disk_type: shield
   stemcell: bionic
   vm_type: small
-name: postgres-shield
+name: secure-shield
 releases:
 - name: shield
   sha1: 523f562c97f4b2538f61e160ba6207a34344a0f0
   url: https://bosh.io/d/github.com/starkandwayne/shield-boshrelease?v=9.0.0
   version: 9.0.0
-- name: shield-addon-postgres
-  sha1: 45fb8d0c4919c55667cb18ee17e5e333a5eb5789
-  url: https://github.com/shieldproject/shield-addon-postgres-boshrelease/releases/download/v1.0.2/shield-addon-postgres-1.0.2.tgz
-  version: 1.0.2
 stemcells:
 - alias: bionic
   os: ubuntu-bionic

--- a/spec/spec_test.go
+++ b/spec/spec_test.go
@@ -30,5 +30,10 @@ var _ = Describe("Shield Kit", func() {
 			CloudConfig: "aws",
 			CPI:         "aws",
 		})
+		Test(Environment{
+			Name:        "secure",
+			CloudConfig: "aws",
+			CPI:         "aws",
+		})
 	})
 })

--- a/spec/vault/secure.yml
+++ b/spec/vault/secure.yml
@@ -1,0 +1,26 @@
+secret/secure/shield/agent:
+  fingerprint: <!{meta.vault}/agent:fingerprint!>
+  private: <!{meta.vault}/agent:private!>
+  public: <!{meta.vault}/agent:public!>
+secret/secure/shield/certs/ca:
+  certificate: <!{meta.vault}/certs/ca:certificate!>
+  combined: <!{meta.vault}/certs/ca:combined!>
+  crl: <!{meta.vault}/certs/ca:crl!>
+  key: <!{meta.vault}/certs/ca:key!>
+  serial: <!{meta.vault}/certs/ca:serial!>
+secret/secure/shield/certs/server:
+  certificate: <!{meta.vault}/certs/server:certificate!>
+  combined: <!{meta.vault}/certs/server:combined!>
+  key: <!{meta.vault}/certs/server:key!>
+secret/secure/shield/failsafe:
+  admin_password: <!{meta.vault}/failsafe:admin_password!>
+secret/secure/shield/vault/ca:
+  certificate: <!{meta.vault}/vault/ca:certificate!>
+  combined: <!{meta.vault}/vault/ca:combined!>
+  crl: <!{meta.vault}/vault/ca:crl!>
+  key: <!{meta.vault}/vault/ca:key!>
+  serial: <!{meta.vault}/vault/ca:serial!>
+secret/secure/shield/vault/server:
+  certificate: <!{meta.vault}/vault/server:certificate!>
+  combined: <!{meta.vault}/vault/server:combined!>
+  key: <!{meta.vault}/vault/server:key!>


### PR DESCRIPTION
[Improvements]

* Added `secure` feature that allows you to use a randomly generated admin password and optionally overwrite the admin username (defaults to `admin`

  By default, the admin username and password have always been static, which generally isn't an issue as shield is deployed internally and you still need the master password.  This adds to the security from internal risks and can be rotated according to corporate security policy.