### PR TITLE
bump shield-boshrelease to v9.1.0

### DIFF
--- a/manifests/releases/shield.yml
+++ b/manifests/releases/shield.yml
@@ -2,6 +2,6 @@
   path: /releases?/name=shield?
   value:
     name: shield
-    version: 9.0.0
-    url: https://bosh.io/d/github.com/starkandwayne/shield-boshrelease?v=9.0.0
-    sha1: 523f562c97f4b2538f61e160ba6207a34344a0f0
+    version: 9.1.0
+    url: https://bosh.io/d/github.com/starkandwayne/shield-boshrelease?v=9.1.0
+    sha1: 3d7023db0c59fc4153df93eeae7a6264c7e97f29

--- a/spec/results/base.yml
+++ b/spec/results/base.yml
@@ -56,9 +56,9 @@ instance_groups:
 name: base-shield
 releases:
 - name: shield
-  sha1: 523f562c97f4b2538f61e160ba6207a34344a0f0
-  url: https://bosh.io/d/github.com/starkandwayne/shield-boshrelease?v=9.0.0
-  version: 9.0.0
+  sha1: 3d7023db0c59fc4153df93eeae7a6264c7e97f29
+  url: https://bosh.io/d/github.com/starkandwayne/shield-boshrelease?v=9.1.0
+  version: 9.1.0
 stemcells:
 - alias: bionic
   os: ubuntu-bionic

--- a/spec/results/oauth.yml
+++ b/spec/results/oauth.yml
@@ -57,9 +57,9 @@ instance_groups:
 name: oauth-shield
 releases:
 - name: shield
-  sha1: 523f562c97f4b2538f61e160ba6207a34344a0f0
-  url: https://bosh.io/d/github.com/starkandwayne/shield-boshrelease?v=9.0.0
-  version: 9.0.0
+  sha1: 3d7023db0c59fc4153df93eeae7a6264c7e97f29
+  url: https://bosh.io/d/github.com/starkandwayne/shield-boshrelease?v=9.1.0
+  version: 9.1.0
 stemcells:
 - alias: bionic
   os: ubuntu-bionic

--- a/spec/results/postgres.yml
+++ b/spec/results/postgres.yml
@@ -58,9 +58,9 @@ instance_groups:
 name: postgres-shield
 releases:
 - name: shield
-  sha1: 523f562c97f4b2538f61e160ba6207a34344a0f0
-  url: https://bosh.io/d/github.com/starkandwayne/shield-boshrelease?v=9.0.0
-  version: 9.0.0
+  sha1: 3d7023db0c59fc4153df93eeae7a6264c7e97f29
+  url: https://bosh.io/d/github.com/starkandwayne/shield-boshrelease?v=9.1.0
+  version: 9.1.0
 - name: shield-addon-postgres
   sha1: 45fb8d0c4919c55667cb18ee17e5e333a5eb5789
   url: https://github.com/shieldproject/shield-addon-postgres-boshrelease/releases/download/v1.0.2/shield-addon-postgres-1.0.2.tgz

--- a/spec/results/secure.yml
+++ b/spec/results/secure.yml
@@ -59,9 +59,9 @@ instance_groups:
 name: secure-shield
 releases:
 - name: shield
-  sha1: 523f562c97f4b2538f61e160ba6207a34344a0f0
-  url: https://bosh.io/d/github.com/starkandwayne/shield-boshrelease?v=9.0.0
-  version: 9.0.0
+  sha1: 3d7023db0c59fc4153df93eeae7a6264c7e97f29
+  url: https://bosh.io/d/github.com/starkandwayne/shield-boshrelease?v=9.1.0
+  version: 9.1.0
 stemcells:
 - alias: bionic
   os: ubuntu-bionic


### PR DESCRIPTION
Shield-boshrelease v9.1.0 has been cut to combine 8.8.5 and 8.8.6 changes.