### PR TITLE
Bump shield boshrelease to 9.3.1 and kit to 2.0.1

### DIFF
--- a/kit.yml
+++ b/kit.yml
@@ -1,6 +1,6 @@
 ---
 name: shield
-version: 2.0.0
+version: 2.0.1
 
 description:   S.H.I.E.L.D. Data Protection
 author: James Hunt <jhunt@starkandwayne.com>

--- a/manifests/releases/shield.yml
+++ b/manifests/releases/shield.yml
@@ -1,5 +1,5 @@
 releases:
 - name:    shield
-  version: 9.3.0
-  url:     https://github.com/shieldproject/shield-boshrelease/releases/download/v9.3.0/shield-boshrelease-9.3.0.tgz
-  sha1:    c229a2fe681d9c4bd42271b461a4bfaea5f3ce7d
+  version: 9.3.1
+  url:     https://github.com/shieldproject/shield-boshrelease/releases/download/v9.3.1/shield-boshrelease-9.3.1.tgz
+  sha1:    e1bdc84bedf6741d544a61506cb5e02221af97cd


### PR DESCRIPTION
## Summary
- Bump shield boshrelease pin 9.3.0 → 9.3.1, sha1 recomputed from the new tarball
- Bump kit version 2.0.0 → 2.0.1 (patch — release-pin-only change)

The new shield-boshrelease v9.3.1 (cut 2026-05-05) refreshes blob versions only — nginx 1.28.3, vault 1.20.4, sqlite 3.47.2, pcre 10.47, and shield-server v9.0.1 — with no new jobs, properties, or manifest schema changes. Operators on 9.3.0 can pick up 9.3.1 with no manifest edits.

No parameter, manifest structure, hook, or `genesis_version_min` drift in the kit.